### PR TITLE
BaSP-MR-98: edit class crash fixed

### DIFF
--- a/src/Components/Classes/Form/index.js
+++ b/src/Components/Classes/Form/index.js
@@ -29,6 +29,7 @@ const Form = ({ updateClass, createCLass, show, updateToggle, classUpdateId, kla
     });
     updateToggle.setUpdateMode(false);
     show();
+    window.location.reload();
   };
 
   const onChangeHour = (e) => {

--- a/src/Components/Classes/Table/index.js
+++ b/src/Components/Classes/Table/index.js
@@ -51,7 +51,7 @@ const Table = ({ data, deleteClass, updateClick, autoDelete, classes }) => {
           </thead>
           <tbody>
             {data.forEach((item) => {
-              if (!item.activity || !item.trainer) {
+              if (!item.activity || !item.trainer.length != 0) {
                 autoDelete(item._id);
               }
             })}

--- a/src/Components/Classes/Table/index.js
+++ b/src/Components/Classes/Table/index.js
@@ -1,11 +1,10 @@
-/* eslint-disable prettier/prettier */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './table.module.css';
-import { ModalConfirm } from '../../Shared';
+import ModalsConfirmation from '../../Shared/Modals/ModalConfirm';
 
-const Table = ({ data, deleteClass, updateClick }) => {
-  const [ modalDeleteConfirmOpen, setModalDeleteConfirmOpen ] = useState(false);
-  const [ selectedItemId, setSelectedItemId ] = useState('');
+const Table = ({ data, deleteClass, updateClick, autoDelete, classes }) => {
+  const [modalDeleteConfirmOpen, setModalDeleteConfirmOpen] = useState(false);
+  const [selectedItemId, setSelectedItemId] = useState('');
 
   const handleDeleteButtonClick = (id) => {
     setSelectedItemId(id);
@@ -16,6 +15,20 @@ const Table = ({ data, deleteClass, updateClick }) => {
     deleteClass(selectedItemId);
     setModalDeleteConfirmOpen(false);
   };
+
+  const getClasses = async () => {
+    try {
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/class`);
+      const data = await response.json();
+      classes.setClasses(data.data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getClasses();
+  }, []);
 
   return (
     <section className={styles.container}>
@@ -37,16 +50,23 @@ const Table = ({ data, deleteClass, updateClick }) => {
             </tr>
           </thead>
           <tbody>
+            {data.forEach((item) => {
+              if (!item.activity || !item.trainer) {
+                autoDelete(item._id);
+              }
+            })}
             {data.map((item, index) => {
               return (
                 <tr key={index}>
-                  <td>{item.activity ? item.activity.name : ''}</td>
+                  <td>{item.activity ? item.activity.name : 'This Activity was DELETED'}</td>
                   <td>{item.day}</td>
                   <td>{item.hour}</td>
                   <td>
-                    {item.trainer ? item.trainer.map((trainerOne) => {
-                      return `${trainerOne.firstName} ${trainerOne.lastName}`;
-                    }) : ''}
+                    {item.trainer
+                      ? item.trainer.map(
+                          (trainerOne) => `${trainerOne.firstName} ${trainerOne.lastName}`
+                        )
+                      : 'This Trainer was DELETED'}
                   </td>
                   <td>{item.slots}</td>
                   <td>
@@ -68,7 +88,7 @@ const Table = ({ data, deleteClass, updateClick }) => {
             })}
           </tbody>
           {modalDeleteConfirmOpen && (
-            <ModalConfirm
+            <ModalsConfirmation
               method="Delete"
               onConfirm={handleModalConfirmation}
               setModalConfirmOpen={setModalDeleteConfirmOpen}

--- a/src/Components/Classes/Table/table.module.css
+++ b/src/Components/Classes/Table/table.module.css
@@ -70,6 +70,4 @@ tbody tr td:nth-last-child(-n + 2) {
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  position: relative;
-  left: 30px;
 }

--- a/src/Components/Classes/index.js
+++ b/src/Components/Classes/index.js
@@ -80,8 +80,18 @@ function Projects() {
     }, 0);
   };
 
-  const updateModeToggle = () => {
-    setUpdateMode(!updateMode);
+  const createMode = () => {
+    showForm();
+    {
+      updateMode && setUpdateMode(false);
+    }
+    setKlass({
+      hour: '',
+      day: '',
+      trainer: '',
+      activity: '',
+      slots: ''
+    });
   };
 
   const deleteClass = (id) => {
@@ -90,7 +100,7 @@ function Projects() {
 
   const updateClick = (item) => {
     showForm();
-    updateModeToggle();
+    setUpdateMode(true);
     setClassUpdateId(item._id);
     setKlass({
       hour: item.hour,
@@ -104,7 +114,7 @@ function Projects() {
   return (
     <section className={styles.container}>
       <h2>Classes</h2>
-      <button type="button" className={styles.button} onClick={showForm}>
+      <button type="button" className={styles.button} onClick={createMode}>
         <img src={`${process.env.PUBLIC_URL}/assets/images/btn-add.png`} /> Add
       </button>
       {show && (

--- a/src/Components/Classes/index.js
+++ b/src/Components/Classes/index.js
@@ -25,7 +25,6 @@ function Projects() {
   const createClass = async (body) => {
     try {
       await fetch(`${process.env.REACT_APP_API_URL}/class`, body);
-      setClasses([...classes, JSON.parse(body.body)]);
       setSuccessMessage('The class has been created successfully.');
       setTimeout(() => {
         window.location.reload();

--- a/src/Components/Classes/index.js
+++ b/src/Components/Classes/index.js
@@ -1,14 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styles from './classes.module.css';
 import Table from './Table/index';
 import Form from './Form/index';
 import { ModalSuccess } from '../Shared';
+import { ToastError } from '../Shared';
 
 function Projects() {
   const [show, setShow] = useState(false);
   const [classes, setClasses] = useState([]);
   const [updateMode, setUpdateMode] = useState(false);
   const [modalSuccessOpen, setModalSuccessOpen] = useState(false);
+  const [toastErrorOpen, setToastErrorOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [classUpdateId, setClassUpdateId] = useState('');
   const [klass, setKlass] = useState({
@@ -19,24 +22,14 @@ function Projects() {
     slots: ''
   });
 
-  const getClasses = async () => {
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/class`);
-      const data = await response.json();
-      setClasses(data.data);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  useEffect(() => {
-    getClasses();
-  }, []);
-
   const createClass = async (body) => {
     try {
       await fetch(`${process.env.REACT_APP_API_URL}/class`, body);
       setClasses([...classes, JSON.parse(body.body)]);
+      setSuccessMessage('The class has been created successfully.');
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
     } catch (error) {
       console.error(error);
     }
@@ -45,19 +38,6 @@ function Projects() {
   const updateClass = async (id, body) => {
     try {
       await fetch(`${process.env.REACT_APP_API_URL}/class/${id}`, body);
-      const bodyParsed = JSON.parse(body.body);
-      const updatingClass = classes.map((item) => {
-        if (item._id === id) {
-          item.hour = bodyParsed.hour;
-          item.day = bodyParsed.day;
-          item.trainer = bodyParsed.trainer;
-          item.activity = bodyParsed.activity;
-          item.slots = bodyParsed.slots;
-          return item;
-        }
-        return item;
-      });
-      setClasses(updatingClass);
     } catch (error) {
       console.error(error);
     }
@@ -74,6 +54,22 @@ function Projects() {
       setClasses([...classes.filter((classes) => classes._id !== id)]);
       setSuccessMessage('The class has been deleted successfully.');
       setModalSuccessOpen(true);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const autoDelete = async (id) => {
+    try {
+      await fetch(`${process.env.REACT_APP_API_URL}/class/${id}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      setClasses([...classes.filter((classes) => classes._id !== id)]);
+      setToastMessage('The Activity or Trainer does not exist');
+      setToastErrorOpen(true);
     } catch (error) {
       console.error(error);
     }
@@ -128,7 +124,18 @@ function Projects() {
           <ModalSuccess setModalSuccessOpen={setModalSuccessOpen} message={successMessage} />
         )}
       </div>
-      <Table updateClick={updateClick} data={classes} deleteClass={deleteClass} />
+      <div>
+        {toastErrorOpen && (
+          <ToastError setToastErroOpen={setToastErrorOpen} message={toastMessage} />
+        )}
+      </div>
+      <Table
+        classes={{ classes, setClasses }}
+        updateClick={updateClick}
+        data={classes}
+        deleteClass={deleteClass}
+        autoDelete={autoDelete}
+      />
     </section>
   );
 }


### PR DESCRIPTION
- when I click to edit a class, the server crashes bug fixed
- added toast error on fail create

the crash is because the autofill of the edit form is not finding any of the activity or trainer id from the selected row, usually because they were deleted.