### PR TITLE
BaSP-MR-326: Fix subscriptions classes

### DIFF
--- a/src/Components/Subscriptions/index.js
+++ b/src/Components/Subscriptions/index.js
@@ -15,6 +15,13 @@ function Subscriptions() {
   const [toastError, setToastErroOpen] = useState(error);
 
   useEffect(() => {
+    for (const subs of subscription) {
+      if (subs.classId === null) {
+        dispatch(deleteSubscription(subs._id));
+      }
+    }
+  }, [subscription, dispatch]);
+  useEffect(() => {
     getSuscription(dispatch);
     getClasses(dispatch);
   }, []);


### PR DESCRIPTION
I fixed that when a class is deleted, the subscription that the class is in is automatically deleted.

- [X] Add that when a class is removed, the subs are removed.